### PR TITLE
feat: pages ci

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Deploy to GitHub Pages
+        env:
+          GIT_USER: ${{ github.actor }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          npm run deploy

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -15,15 +15,15 @@ const config: Config = {
   },
 
   // Set the production url of your site here
-  url: 'https://your-docusaurus-site.example.com',
+  url: 'https://nakata-midori.github.io', // GitHub PagesのURL
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
-  baseUrl: '/',
+  baseUrl: '/sample-docs/', // リポジトリ名で終わるように
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.
-  organizationName: 'facebook', // Usually your GitHub org/user name.
-  projectName: 'docusaurus', // Usually your repo name.
+  organizationName: 'nakata-midori', // GitHubユーザー名
+  projectName: 'sample-docs', // リポジトリ名
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',


### PR DESCRIPTION
mainにマージされると、actionsが動き、npm run deployが実行される。
そうすると、Docusaurusというドキュメントエンジンのdeployコマンドが実行される。
このコマンドが行うのは以下

- ドキュメントがビルドされ、htmlの生成物がコマンド実行環境（この場合actions実行環境）の`build/`に配置される
- そしてさらに、gh-pagesブランチのトップディレクトリに、その`build/`内の生成物が、コピーされてpushされる