### PR TITLE
PRを作成したユーザーがgit pushに使われないようにした

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,7 +30,6 @@ jobs:
 
       - name: Deploy to GitHub Pages
         env:
-          GIT_USER: ${{ github.actor }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           npm run deploy

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -19,6 +19,7 @@ const config: Config = {
   // Set the /<baseUrl>/ pathname under which your site is served
   // For GitHub pages deployment, it is often '/<projectName>/'
   baseUrl: '/sample-docs/', // リポジトリ名で終わるように
+  trailingSlash: true,
 
   // GitHub pages deployment config.
   // If you aren't using GitHub pages, you don't need these.


### PR DESCRIPTION
gh-pagesブランチへのpush時に、PRを作成したユーザーが使われる設定になっており、パスワードが設定されてないので、こけた。

githubのトークンのみを使うようにした。

ついでに、ワーニングが出ていた部分を修正。URLのパスが全て/で終わるようにしないとGitHub Pagesだと挙動が不安定になるよ、というワーニングで、/で終わるような設定にした。